### PR TITLE
also parse wpt tags

### DIFF
--- a/gips.rb
+++ b/gips.rb
@@ -41,7 +41,7 @@ Clamp do
     previous = nil
     output = []
 
-    points = doc.css('rtept,trkpt').map {|p| [p['lat'].to_f, p['lon'].to_f]}.uniq
+    points = doc.css('rtept,trkpt,wpt').map {|p| [p['lat'].to_f, p['lon'].to_f]}.uniq
 
     puts "Found #{points.count} route points in #{infile}."
 


### PR DESCRIPTION
Also parse files that use the `wpt` tag instead of the track or route format. (The wpt format is what that script outputs, as it is what the simulator needs, and it is also the format of the sample routes)

fixes #1 
